### PR TITLE
Expose same port on Service that is defined on Deployment

### DIFF
--- a/pkg/reconciler/workload/translate.go
+++ b/pkg/reconciler/workload/translate.go
@@ -184,7 +184,7 @@ func ServiceInjector(ctx context.Context, w Workload, objs []Object) ([]Object, 
 				s.Spec.Ports = []corev1.ServicePort{
 					{
 						Name:       d.GetName(),
-						Port:       8080,
+						Port:       d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort,
 						TargetPort: intstr.FromInt(int(d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)),
 					},
 				}

--- a/pkg/reconciler/workload/translate_test.go
+++ b/pkg/reconciler/workload/translate_test.go
@@ -119,7 +119,7 @@ func sWithContainerPort(target int) serviceModifier {
 	return func(s *corev1.Service) {
 		s.Spec.Ports = append(s.Spec.Ports, corev1.ServicePort{
 			Name:       workloadName,
-			Port:       8080,
+			Port:       int32(target),
 			TargetPort: intstr.FromInt(target),
 		})
 	}


### PR DESCRIPTION
This is a minor change that causes the `Service` to expose the same port that is defined on the `Deployment`. I think this is more predictable for the time-being than always using `8080`. (Note: this is also how `rudr` handles ports from what I can tell).

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>