### PR TITLE
Bump crossplane and crossplane-runtime dependencies for back-up and restore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/crossplane/addon-oam-kubernetes-remote
 go 1.13
 
 require (
-	github.com/crossplane/crossplane v0.10.0-rc.0.20200403002801-93da62f1cccb
-	github.com/crossplane/crossplane-runtime v0.6.0
+	github.com/crossplane/crossplane v0.10.0-rc.0.20200409212715-ae92a6215aa4
+	github.com/crossplane/crossplane-runtime v0.7.1-0.20200413203236-642fd735cad7
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	sigs.k8s.io/controller-runtime v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,11 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea h1:n2Ltr3SrfQlf/9nOna1D
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/crossplane/crossplane v0.10.0-rc.0.20200403002801-93da62f1cccb h1:ZlqSv5FU2BIDw857Z6OdkVXSeXCigaebfYwt3NXK4j8=
-github.com/crossplane/crossplane v0.10.0-rc.0.20200403002801-93da62f1cccb/go.mod h1:cot5wl1GX0nCXZUMgoLa9xIg/Cs+aRr5j/+Pqks1hXI=
-github.com/crossplane/crossplane-runtime v0.6.0 h1:MPATmc2/vX+ja5+ZDxpl1iMdSSKEs9fVwKBVdq1VBSg=
-github.com/crossplane/crossplane-runtime v0.6.0/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
+github.com/crossplane/crossplane v0.10.0-rc.0.20200409212715-ae92a6215aa4 h1:UhImOmS/ChO4Fv3b8q8sHlewrEuRtcKx2KZ9ccUtFfo=
+github.com/crossplane/crossplane v0.10.0-rc.0.20200409212715-ae92a6215aa4/go.mod h1:fSZUAVI801Udr0i4UeIAKb3iK5ZASL7YZ3tNpzNQC8k=
+github.com/crossplane/crossplane-runtime v0.6.1-0.20200406020956-f9d4e859f450/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
+github.com/crossplane/crossplane-runtime v0.7.1-0.20200413203236-642fd735cad7 h1:tDkwO/GG4Rz1c+ITk8RNvUwwHVcnw5sTf2kwPKuTWFE=
+github.com/crossplane/crossplane-runtime v0.7.1-0.20200413203236-642fd735cad7/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330 h1:zxdYGQnQbfyZSnRbKUJ16x5lRzkUTbH+uumVq03ijYo=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/pkg/controller/containerizedworkload/containerizedworkload.go
+++ b/pkg/controller/containerizedworkload/containerizedworkload.go
@@ -42,7 +42,7 @@ func SetupContainerizedWorkload(mgr ctrl.Manager, l logging.Logger) error {
 			resource.WorkloadKind(oamv1alpha2.ContainerizedWorkloadGroupVersionKind),
 			workload.WithLogger(l.WithValues("controller", name)),
 			workload.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
-			workload.WithApplyOptions(resource.ControllersMustMatch(), apply.KubeAppApplyOption()),
+			workload.WithApplyOptions(apply.KubeAppApplyOption()),
 			workload.WithTranslator(workload.NewObjectTranslatorWithWrappers(
 				containerized.Translator,
 				client.ServiceInjector,

--- a/pkg/controller/containerizedworkload/manualscaler.go
+++ b/pkg/controller/containerizedworkload/manualscaler.go
@@ -41,6 +41,7 @@ func SetupManualScalerTrait(mgr ctrl.Manager, l logging.Logger) error {
 		For(&oamv1alpha2.ManualScalerTrait{}).
 		Complete(trait.NewReconciler(mgr,
 			resource.TraitKind(oamv1alpha2.ManualScalerTraitGroupVersionKind),
+			resource.WorkloadKind(oamv1alpha2.ContainerizedWorkloadGroupVersionKind),
 			resource.ObjectKind(workloadv1alpha1.KubernetesApplicationGroupVersionKind),
 			trait.WithLogger(l.WithValues("controller", name)),
 			trait.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),


### PR DESCRIPTION
The primary change introduced by this update is the passing of the workload kind to the trait reconciler so that it can confirm that the translations it modified are controllable by the workload it references.

Tested by successfully deploying flight-tracker on GCP, All components were translated and modified successfully.

*Draft until merge of https://github.com/crossplane/crossplane-runtime/pull/145*

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>