### PR TITLE
Update dependencies to correct OAM apiVersion

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -45,7 +45,7 @@ source: "https://github.com/crossplane/addon-oam-kubernetes-remote"
 permissionScope: Cluster
 dependsOn:
 - crd: '*.workload.crossplane.io/v1alpha1'
-- crd: '*.oam.crossplane.io/v1alpha2'
+- crd: '*.core.oam.dev/v1alpha2'
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0


### PR DESCRIPTION
The current `app.yaml` does not request RBAC for the correct apiVersion of OAM core types.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>